### PR TITLE
Fix dist package.json path in build and bump version to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altd",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Access log tail dispatcher",
   "type": "module",
   "bin": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,7 +9,9 @@ const distDir = join(projectRoot, 'dist');
 await mkdir(distDir, { recursive: true });
 
 const indexSource = await readFile(join(projectRoot, 'index.js'), 'utf8');
-const indexOutput = indexSource.replace('./src/altd.js', './altd.js');
+const indexOutput = indexSource
+  .replace('./src/altd.js', './altd.js')
+  .replace('./package.json', '../package.json');
 
 await writeFile(join(distDir, 'index.js'), indexOutput);
 await copyFile(join(projectRoot, 'src', 'altd.js'), join(distDir, 'altd.js'));


### PR DESCRIPTION
### Motivation
- Ensure runtime import inside `dist/index.js` resolves to the project-root `package.json` because `./package.json` is not present inside `dist`.
- Prevent the globally-installed CLI from failing due to an incorrect relative path to `package.json` at runtime.
- Bump the package version to `0.0.4` to publish the fix and reflect the change.

### Description
- Update `scripts/build.js` to transform `index.js` output by replacing `./src/altd.js` with `./altd.js` and `./package.json` with `../package.json` when generating `dist/index.js`.
- Preserve existing behavior of writing the transformed `index.js` into `dist` and copying `src/altd.js` to `dist/altd.js`.
- Update the `version` field in `package.json` to `0.0.4`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695784efaa08832fa452869535b221fc)