### PR TITLE
Remove PATH checks and security limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 # altd
 Web server access log tail dispatcher for running whitelisted commands based on GET requests.
 
+This tool runs the command names you whitelist exactly as provided. There is no PATH
+resolution, argument validation, rate limiting, or output limiting built in. Treat the
+access log source as trusted input.
+
 ## Requirements
 
 - Node.js 18 or later
@@ -29,13 +33,28 @@ altd <access_log.file> -w [commands]
 
 - `-V, --version` output the version number
 - `-h, --help` output usage information
-- `-w, --whitelist <commands>` comma-separated list of allowed commands
+- `-w, --whitelist <commands>` comma-separated list of allowed commands (executed directly)
 
 ## Example
 
 ```bash
 altd /var/log/nginx/access_log -w ls,hostname
 ```
+
+Log lines are expected to include a request line like:
+
+```
+GET /hostname HTTP/1.1
+```
+
+This would execute `hostname` with no arguments. Additional path segments are passed as
+arguments, for example:
+
+```
+GET /ls/-la HTTP/1.1
+```
+
+Would execute: `ls -la`.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-import { accessSync, constants } from 'node:fs';
 import { createRequire } from 'node:module';
-import { delimiter, isAbsolute, join } from 'node:path';
 import { Command } from 'commander';
 import AccessLogTailDispatcher from './src/altd.js';
 
@@ -10,52 +8,12 @@ const pkg = require('./package.json');
 
 const program = new Command();
 
-const resolveExecPath = (command) => {
-  if (!command || typeof command !== 'string') return null;
-  if (isAbsolute(command)) {
-    try {
-      accessSync(command, constants.X_OK);
-      return command;
-    } catch {
-      return null;
-    }
-  }
-
-  const searchPaths = (process.env.PATH ?? '').split(delimiter);
-  for (const dir of searchPaths) {
-    if (!dir) continue;
-    const candidate = join(dir, command);
-    try {
-      accessSync(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      // continue
-    }
-  }
-  return null;
-};
-
 const buildRegistry = (whitelist) => {
   const registry = {};
   for (const command of whitelist) {
-    const execPath = resolveExecPath(command);
-    if (!execPath) {
-      console.warn(`[altd] skip command: ${command}`);
-      continue;
-    }
     registry[command] = {
-      execPath,
-      buildArgs: (rawArgs) => {
-        if (!Array.isArray(rawArgs) || rawArgs.length > 20) {
-          throw new Error('invalid args');
-        }
-        for (const arg of rawArgs) {
-          if (typeof arg !== 'string' || arg.length > 256) {
-            throw new Error('invalid args');
-          }
-        }
-        return rawArgs;
-      },
+      execPath: command,
+      buildArgs: (rawArgs) => rawArgs,
     };
   }
   return registry;
@@ -82,10 +40,6 @@ if (!fileValue || !whitelist || whitelist.length === 0) {
 }
 
 const registry = buildRegistry(whitelist);
-if (Object.keys(registry).length === 0) {
-  console.error('[altd] no valid commands to run');
-  process.exit(1);
-}
 
 const altd = new AccessLogTailDispatcher(fileValue, registry);
 altd.run();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altd",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Access log tail dispatcher",
   "type": "module",
   "bin": {

--- a/test/altd.test.js
+++ b/test/altd.test.js
@@ -53,10 +53,6 @@ describe('AccessLogTailDispatcher', () => {
 
     expect(altd.file).toBe('/path/to/dir');
     expect(altd.registry).toBe(registry);
-    expect(altd.windowMs).toBe(1000);
-    expect(altd.maxPerWindow).toBe(5);
-    expect(altd.timeoutMs).toBe(10_000);
-    expect(altd.maxStdoutBytes).toBe(64 * 1024);
   });
 
   it('extracts a pathname from log lines', () => {
@@ -65,7 +61,6 @@ describe('AccessLogTailDispatcher', () => {
 
     expect(altd.extractPath({})).toBe('');
     expect(altd.extractPath('')).toBe('');
-    expect(altd.extractPath('x'.repeat(10_001))).toBe('');
     expect(altd.extractPath('POST /not-a-get HTTP/1.1')).toBe('/not-a-get');
     expect(
       altd.extractPath(
@@ -95,8 +90,6 @@ describe('AccessLogTailDispatcher', () => {
     expect(altd.parseCommand('')).toEqual([]);
     expect(altd.parseCommand('no-slash')).toEqual([]);
     expect(altd.parseCommand('/')).toEqual([]);
-    expect(altd.parseCommand('/' + 'a'.repeat(2049))).toEqual([]);
-    expect(altd.parseCommand('/tool/' + 'b'.repeat(257))).toEqual([]);
     expect(altd.parseCommand('/google-home-notifier/Hello%20World')).toEqual([
       'google-home-notifier',
       'Hello World',
@@ -104,29 +97,10 @@ describe('AccessLogTailDispatcher', () => {
     expect(altd.parseCommand('/test/%E0%A4%A')).toEqual([]);
   });
 
-  it('rate limits execution', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
-    const registry = { echo: { execPath: '/bin/echo', buildArgs: (args) => args } };
-    const altd = new AccessLogTailDispatcher('/path/to/dir', registry, {
-      windowMs: 1000,
-      maxPerWindow: 2,
-    });
-
-    expect(altd.allowByRateLimit()).toBe(true);
-    expect(altd.allowByRateLimit()).toBe(true);
-    expect(altd.allowByRateLimit()).toBe(false);
-
-    vi.setSystemTime(new Date('2024-01-01T00:00:02Z'));
-    expect(altd.allowByRateLimit()).toBe(true);
-    vi.useRealTimers();
-  });
-
   it('resolves execution via registry', () => {
     const registry = {
       echo: { execPath: '/bin/echo', buildArgs: (args) => args.slice(0, 1) },
       bad: { execPath: '/bin/bad', buildArgs: () => 'nope' },
-      fail: { execPath: '/bin/fail', buildArgs: () => { throw new Error('no'); } },
     };
     const altd = new AccessLogTailDispatcher('/path/to/dir', registry);
 
@@ -137,65 +111,30 @@ describe('AccessLogTailDispatcher', () => {
     expect(altd.resolveExecution('nope')).toBeNull();
     expect(altd.resolveExecution(['missing'])).toBeNull();
     expect(altd.resolveExecution(['bad', 'x'])).toBeNull();
-    expect(altd.resolveExecution(['fail', 'x'])).toBeNull();
     expect(altd.resolveExecution([])).toBeNull();
   });
 
-  it('spawns with limits and handles output', () => {
+  it('spawns commands with the configured spawn implementation', () => {
     const registry = { echo: { execPath: '/bin/echo', buildArgs: (args) => args } };
-    const stdoutWriteSpy = vi
-      .spyOn(process.stdout, 'write')
-      .mockImplementation(() => true);
-    const stderrWriteSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation(() => true);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const handlers = {};
-    const stdoutHandlers = {};
-    const stderrHandlers = {};
     const proc = {
-      stdout: {
-        on: vi.fn((event, handler) => {
-          stdoutHandlers[event] = handler;
-        }),
-      },
-      stderr: {
-        on: vi.fn((event, handler) => {
-          stderrHandlers[event] = handler;
-        }),
-      },
       on: vi.fn((event, handler) => {
         handlers[event] = handler;
       }),
-      kill: vi.fn(),
     };
 
     spawnMock.mockReturnValue(proc);
 
-    const altd = new AccessLogTailDispatcher('/path/to/dir', registry, {
-      spawnImpl: spawnMock,
-      timeoutMs: 1,
-      maxStdoutBytes: 3,
-    });
+    const altd = new AccessLogTailDispatcher('/path/to/dir', registry, { spawnImpl: spawnMock });
 
-    altd.spawnLimited('/bin/echo', ['hello']);
+    altd.spawnCommand('/bin/echo', ['hello']);
 
     expect(spawnMock).toHaveBeenCalledWith('/bin/echo', ['hello'], expect.any(Object));
 
-    stdoutHandlers.data(Buffer.from('ok'));
-    expect(stdoutWriteSpy).toHaveBeenCalledWith(Buffer.from('ok'));
-
-    stdoutHandlers.data(Buffer.from('toolong'));
-    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
-
-    stderrHandlers.data(Buffer.from('err'));
-    expect(stderrWriteSpy).toHaveBeenCalledWith(Buffer.from('err'));
-
     handlers.error(new Error('boom'));
     expect(errorSpy).toHaveBeenCalled();
-
-    handlers.exit();
   });
 
   it('wires tail events and dispatches on matching lines', () => {
@@ -203,7 +142,7 @@ describe('AccessLogTailDispatcher', () => {
       command1: { execPath: '/bin/echo', buildArgs: (args) => args },
     };
     const altd = new AccessLogTailDispatcher('/path/to/dir', registry);
-    const spawnSpy = vi.spyOn(altd, 'spawnLimited').mockImplementation(() => {});
+    const spawnSpy = vi.spyOn(altd, 'spawnCommand').mockImplementation(() => {});
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     altd.run();
@@ -237,14 +176,12 @@ describe('AccessLogTailDispatcher', () => {
     expect(tailInstances[0].unwatch).toHaveBeenCalled();
   });
 
-  it('ignores rate-limited or invalid commands', () => {
+  it('ignores invalid commands', () => {
     const registry = {
       command1: { execPath: '/bin/echo', buildArgs: (args) => args },
     };
-    const altd = new AccessLogTailDispatcher('/path/to/dir', registry, {
-      maxPerWindow: 0,
-    });
-    const spawnSpy = vi.spyOn(altd, 'spawnLimited').mockImplementation(() => {});
+    const altd = new AccessLogTailDispatcher('/path/to/dir', registry);
+    const spawnSpy = vi.spyOn(altd, 'spawnCommand').mockImplementation(() => {});
 
     altd.run();
 
@@ -258,7 +195,7 @@ describe('AccessLogTailDispatcher', () => {
       '127.0.0.1 - - [01/Jan/2024:00:00:00 +0000] "GET /missing/arg1 HTTP/1.1" 200 0 "-" "UA"'
     );
 
-    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('stops safely when tail has no unwatch', () => {

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('build script', () => {
+  it('writes dist output with updated import paths', async () => {
+    await import('../scripts/build.js');
+
+    const distIndex = await readFile(join(process.cwd(), 'dist', 'index.js'), 'utf8');
+    const distAltd = await readFile(join(process.cwd(), 'dist', 'altd.js'), 'utf8');
+
+    expect(distIndex).toContain('./altd.js');
+    expect(distIndex).toContain('../package.json');
+    expect(distAltd).toContain('AccessLogTailDispatcher');
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runSpy = vi.fn();
+const ctorSpy = vi.fn();
+const mockDispatcher = vi.fn();
+
+vi.mock('../src/altd.js', () => ({
+  default: mockDispatcher,
+}));
+
+describe('cli', () => {
+  let originalArgv;
+  let originalExit;
+
+  beforeEach(() => {
+    originalArgv = process.argv;
+    originalExit = process.exit;
+    runSpy.mockReset();
+    ctorSpy.mockReset();
+    mockDispatcher.mockReset();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exit = originalExit;
+    vi.restoreAllMocks();
+  });
+
+  it('exits with usage when required args are missing', async () => {
+    process.argv = ['node', 'index.js', '/tmp/access.log'];
+    process.exit = vi.fn((code) => {
+      throw new Error(`exit ${code}`);
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mockDispatcher.mockImplementation((file, registry) => {
+      ctorSpy(file, registry);
+      return { run: runSpy };
+    });
+
+    await expect(import('../index.js')).rejects.toThrow('exit 1');
+    expect(logSpy).toHaveBeenCalledWith('altd <file> -w <commands...>');
+  });
+
+  it('builds a registry and runs the dispatcher', async () => {
+    process.argv = ['node', 'index.js', '/tmp/access.log', '-w', 'echo,ls'];
+    process.exit = vi.fn();
+
+    mockDispatcher.mockImplementation((file, registry) => {
+      ctorSpy(file, registry);
+      return { run: runSpy };
+    });
+
+    await import('../index.js');
+
+    expect(ctorSpy).toHaveBeenCalledTimes(1);
+    const [, registry] = ctorSpy.mock.calls[0];
+    expect(registry.echo.execPath).toBe('echo');
+    expect(registry.echo.buildArgs(['a'])).toEqual(['a']);
+    expect(registry.ls.execPath).toBe('ls');
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- The code was overly strict about executable resolution and argument/output/time limits, preventing simple use-cases. 
- The goal is to relax those checks so commands can be provided directly and run without PATH/file-access gating. 
- Simplify runtime behavior to make the dispatcher more permissive and easier to integrate. 

### Description
- Removed PATH-based executable resolution and `accessSync` checks and now the CLI registry maps command names directly to the provided command string (changes in `index.js`).
- Simplified registry argument handling so `buildArgs` returns raw args and `resolveExecution` falls back to the per-entry `buildArgs` if present (changes in `src/altd.js`).
- Dropped rate limiting, process timeout, stdout-size caps, strict env/`PATH` overrides, and complex stdout/stderr piping, and replaced `spawnLimited` with `spawnCommand` using `stdio: "inherit"` (changes in `src/altd.js`).
- Updated tests in `test/altd.test.js` to reflect the relaxed parsing and spawning behavior and renamed/adjusted assertions accordingly.

### Testing
- Ran `npm install` successfully to ensure dependencies are up to date. 
- Ran `npm test` and all test files executed with `9` tests passing. 
- The test run reported successful execution of `test/altd.test.js` with all assertions passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69578ce0d130832f83406ae1f1070367)