### PR TITLE
Bump version to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altd",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Access log tail dispatcher",
   "type": "module",
   "bin": {


### PR DESCRIPTION
### Motivation
- Publish a new package version after introducing configurable runtime and input limits to the dispatcher in the codebase.
- Add safeguards to prevent runaway command spawning via concurrency and rate limits and to harden input parsing with path/part/arg size limits.
- Ensure the package metadata reflects the latest behavior changes.

### Description
- Updated `package.json` to set the `version` to `0.0.7`.
- Added new runtime options and tracking fields in `src/altd.js`: `maxConcurrent`, `minIntervalMs`, `maxParts`, `maxPartLength`, `maxArgLength`, `maxPathLength`, `activeCount`, and `lastExecAt`.
- Enforced input limits in `extractPath`, `parseCommand`, and `resolveExecution`, and implemented concurrency and rate limiting in `spawnCommand` with decrement on `close`/`exit`.
- Updated `test/altd.test.js` to assert new defaults and to cover the new limit and spawn behaviors.

### Testing
- Ran the test suite with `npm test` (Vitest) after the dispatcher limit changes and it completed successfully with all tests passing (3 test files, 15 tests passed).
- The version bump commit itself did not trigger an automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695847f08294832fb15287498de388ec)