### PR TITLE
Bump version to 0.0.8 and increase default parsing limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altd",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Access log tail dispatcher",
   "type": "module",
   "bin": {

--- a/src/altd.js
+++ b/src/altd.js
@@ -20,10 +20,10 @@ export default class AccessLogTailDispatcher {
       });
     this.maxConcurrent = opts.maxConcurrent ?? Infinity;
     this.minIntervalMs = opts.minIntervalMs ?? 0;
-    this.maxParts = opts.maxParts ?? 32;
-    this.maxPartLength = opts.maxPartLength ?? 200;
+    this.maxParts = opts.maxParts ?? 64;
+    this.maxPartLength = opts.maxPartLength ?? 1024;
     this.maxArgLength = opts.maxArgLength ?? this.maxPartLength;
-    this.maxPathLength = opts.maxPathLength ?? 2048;
+    this.maxPathLength = opts.maxPathLength ?? 8192;
     this.activeCount = 0;
     this.lastExecAt = Number.NEGATIVE_INFINITY;
   }

--- a/test/altd.test.js
+++ b/test/altd.test.js
@@ -55,10 +55,10 @@ describe('AccessLogTailDispatcher', () => {
     expect(altd.registry).toBe(registry);
     expect(altd.maxConcurrent).toBe(Infinity);
     expect(altd.minIntervalMs).toBe(0);
-    expect(altd.maxParts).toBe(32);
-    expect(altd.maxPartLength).toBe(200);
-    expect(altd.maxArgLength).toBe(200);
-    expect(altd.maxPathLength).toBe(2048);
+    expect(altd.maxParts).toBe(64);
+    expect(altd.maxPartLength).toBe(1024);
+    expect(altd.maxArgLength).toBe(1024);
+    expect(altd.maxPathLength).toBe(8192);
   });
 
   it('extracts a pathname from log lines', () => {


### PR DESCRIPTION
### Motivation
- The previous default `maxPartLength` of 200 was too restrictive for some request paths and needs to be increased to handle larger segments.
- Related limits such as per-path parts and overall path length should be raised to remain consistent with larger segment sizes.
- The package version must be bumped to `0.0.8` per the request.

### Description
- Update `src/altd.js` defaults: `maxParts` from `32` to `64`, `maxPartLength` from `200` to `1024`, and `maxPathLength` from `2048` to `8192`, while keeping `maxArgLength` defaulting to `maxPartLength`.
- Update `test/altd.test.js` expectations to match the new defaults.
- Bump `package.json` `version` to `0.0.8`.

### Testing
- Ran `npm test` with `vitest` after the parsing-limit changes and all tests passed (`15 passed`).
- The version-only bump commit itself did not trigger an additional test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6958b304cc38832faf8d37fa0716e9bb)