### PR TITLE
Fix util.isArray deprecation warning and bump version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altd",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "Access log tail dispatcher",
   "type": "module",
   "bin": {

--- a/src/altd.js
+++ b/src/altd.js
@@ -1,5 +1,11 @@
 import { spawn as nodeSpawn } from "node:child_process";
-import Tail from "nodejs-tail";
+import util from "node:util";
+
+if (util.isArray !== Array.isArray) {
+  util.isArray = Array.isArray;
+}
+
+const { default: Tail } = await import("nodejs-tail");
 
 export default class AccessLogTailDispatcher {
   /**


### PR DESCRIPTION
### Motivation
- Silence the Node deprecation warning about `util.isArray` by ensuring code uses `Array.isArray()` semantics before loading a dependency that may reference the deprecated API. 
- Bump the package minor version as requested to reflect the change in behavior.

### Description
- Patch `util.isArray` to point to `Array.isArray` early in module initialization by importing `node:util` and setting `util.isArray = Array.isArray` when different. 
- Load `nodejs-tail` via a dynamic `await import("nodejs-tail")` and use its default export as `Tail` so the patch runs before the dependency is evaluated and Vitest mocks continue to work. 
- Keep the existing `spawn` usage from `node:child_process` unchanged. 
- Bump `package.json` version from `0.0.8` to `0.1.0`.

### Testing
- Ran the test suite with `npm test` (Vitest) and all automated tests passed: `15 passed` across `3` test files. 
- Coverage report from V8: `Statements 100%`, `Functions 100%`, `Lines 100%`, `Branches ~97%` as shown by the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b1f007898832f836b779b487c1a3a)