### PR TITLE
Remove util.isArray shim to silence deprecation and bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "altd",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Access log tail dispatcher",
   "type": "module",
   "bin": {

--- a/src/altd.js
+++ b/src/altd.js
@@ -1,9 +1,4 @@
 import { spawn as nodeSpawn } from "node:child_process";
-import util from "node:util";
-
-if (util.isArray !== Array.isArray) {
-  util.isArray = Array.isArray;
-}
 
 const { default: Tail } = await import("nodejs-tail");
 


### PR DESCRIPTION
### Motivation
- Remove the compatibility shim for `util.isArray` that triggers a Node deprecation warning and publish a patch release `0.1.1`.

### Description
- Deleted the `import util` and the `util.isArray = Array.isArray` shim from `src/altd.js`, and updated the package version in `package.json` to `0.1.1`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b54424fb4832f960fcf662d637cbd)